### PR TITLE
Do not log every _flush_queues_to_disk()

### DIFF
--- a/vspc/server.py
+++ b/vspc/server.py
@@ -115,7 +115,6 @@ class BackgroundWriter(threading.Thread):
             self._writes_available.set()
 
     def _flush_queues_to_disk(self):
-        LOG.debug("Start flushing data to disk")
         self._data_available_estimate = 0
 
         for uuid in list(self._write_queues):
@@ -130,7 +129,6 @@ class BackgroundWriter(threading.Thread):
 
             with (self._serial_log_dir / uuid).open('ab') as f:
                 f.write(data)
-        LOG.debug("flushing data to disk done")
 
     def run(self):
         LOG.debug("Starting background writer")


### PR DESCRIPTION
The amount of logging done by the regular (every 5s) call to `_flush_queues_to_disk()` isn't really helpful and clutters the view on what's actually happening in the vspc service. Therefore, we remove it.

We do not change it to show the amount of bytes written, when there was actual writing, as big regions with large amounts of VMs will probably write something all the time, so this information will not be too helpful, I'd guess.