### PR TITLE
Drop installing dumb-init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ LABEL source_repository="https://github.com/sapcc/vmware-vspc"
 WORKDIR /usr/src/app
 COPY . .
 
-RUN PBR_VERSION=0.0.3 pip install . dumb-init
+RUN PBR_VERSION=0.0.3 pip install .
 
 CMD [ "vmware-vspc", "--config-file", "/etc/vspc.conf" ]


### PR DESCRIPTION
It was only needed in very old k8s/containerd setups.